### PR TITLE
fix: Off-by-1 enum terminator value

### DIFF
--- a/mesh/dfu/api/nrf_mesh_dfu_types.h
+++ b/mesh/dfu/api/nrf_mesh_dfu_types.h
@@ -153,7 +153,7 @@ typedef enum
     NRF_MESH_DFU_END_ERROR_BANK_AND_DESTINATION_OVERLAP,    /**< When copying the finished bank to its intended destination, it will have to overwrite itself. */
 
     /** @internal Largest number in the enum. */
-    NRF_MESH_DFU_END_ERROR__LAST = NRF_MESH_DFU_END_ERROR_BANK_IN_BOOTLOADER_AREA,
+    NRF_MESH_DFU_END_ERROR__LAST = NRF_MESH_DFU_END_ERROR_BANK_AND_DESTINATION_OVERLAP,
 } nrf_mesh_dfu_end_t;
 
 /** The various roles a device can play in a dfu transfer. */


### PR DESCRIPTION
It looks like the `NRF_MESH_DFU_END_ERROR_BANK_AND_DESTINATION_OVERLAP` enum value was added to `nrf_mesh_dfu_end_t` but the `NRF_MESH_DFU_END_ERROR__LAST` value not updated.

This should be a pretty benign error as the enum is only statically bounds-checked against the type range, but correcting it protects future runtime boundary checks from spurious errors.